### PR TITLE
Fix bug in bwd hooks

### DIFF
--- a/easy_transformer/hook_points.py
+++ b/easy_transformer/hook_points.py
@@ -193,7 +193,7 @@ class HookedRootModule(nn.Module):
                         hp.add_hook(hook, dir="fwd")
         for name, hook in bwd_hooks:
             if type(name) == str:
-                self.mod_dict[name].add_hook(hook, dir="fwd")
+                self.mod_dict[name].add_hook(hook, dir="bwd")
             else:
                 # Otherwise, name is a Boolean function on names
                 for hook_name, hp in self.hook_dict:


### PR DESCRIPTION
They were sometimes getting registered as fwd.

I didn't try running this (just noticed it on GH), but seems obviously right.