### PR TITLE
Remove _quantize_ondevice_ptq_dynamic import

### DIFF
--- a/easy_transformer/hook_points.py
+++ b/easy_transformer/hook_points.py
@@ -2,7 +2,6 @@
 import logging
 from typing import Callable, Union, Optional, Sequence
 import torch
-from torch._C import _quantize_ondevice_ptq_dynamic
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim


### PR DESCRIPTION
The commit ['Added run_with_cache'](https://github.com/neelnanda-io/Easy-Transformer/commit/1d05765937e238abfd7b75ed05ca6f467fffe7f2) caused an ImportError when importing EasyTransformer on Google Colab.

 ```
!pip install git+https://github.com/neelnanda-io/Easy-Transformer.git
from easy_transformer import EasyTransformer
```
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[<ipython-input-3-eaa29a0c1bcc>](https://localhost:8080/#) in <module>
----> 1 from easy_transformer import EasyTransformer

1 frames
[/usr/local/lib/python3.7/dist-packages/easy_transformer/__init__.py](https://localhost:8080/#) in <module>
----> 1 from . import hook_points
      2 from . import EasyTransformer
      3 from . import experiments
      4 from . import utils
      5 from .caching import (

[/usr/local/lib/python3.7/dist-packages/easy_transformer/hook_points.py](https://localhost:8080/#) in <module>
      3 from typing import Callable, Union, Optional, Sequence
      4 import torch
----> 5 from torch._C import _quantize_ondevice_ptq_dynamic
      6 import torch.nn as nn
      7 import torch.nn.functional as F

ImportError: cannot import name '_quantize_ondevice_ptq_dynamic' from 'torch._C' (/usr/local/lib/python3.7/dist-packages/torch/_C.cpython-37m-x86_64-linux-gnu.so)
```

I forked this, removed the import, then tried `!pip install git+https://github.com/met45/Easy-Transformer.git`, and that seems to work. The import seemed to be unused, so I'm guessing that this doesn't secretly break anything else.
