### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/todo-workflow.yaml
+++ b/.github/workflows/todo-workflow.yaml
@@ -1,0 +1,14 @@
+name: TODO workflow
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run tdg-github-action
+      uses: ribtoks/tdg-github-action@master
+      with:
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.sha }}
+        REF: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__
 Testing_Notebook.ipynb
-\.*
 easy_transformer/scratch.py
+.vscode/
 wandb*
 easy_transformer\.egg*
 MANIFEST.in

--- a/EasyTransformer_Demo.ipynb
+++ b/EasyTransformer_Demo.ipynb
@@ -310,7 +310,7 @@
     "\n",
     "Note: OPT-350M is not supported - it applies the LayerNorms to the *outputs* of each layer, which means we cannot fold the weights and biases into other layers, and would require notably different architecture.\n",
     "\n",
-    "**TODO:** Add in GPT-J and GPT-NeoX functionality\n",
+    "// **TODO:** Add in GPT-J and GPT-NeoX functionality\n",
     "\n",
     "The list of supported model names:\n",
     "```\n",

--- a/EasyTransformer_Demo.ipynb
+++ b/EasyTransformer_Demo.ipynb
@@ -310,7 +310,6 @@
     "\n",
     "Note: OPT-350M is not supported - it applies the LayerNorms to the *outputs* of each layer, which means we cannot fold the weights and biases into other layers, and would require notably different architecture.\n",
     "\n",
-    "// **TODO:** Add in GPT-J and GPT-NeoX functionality\n",
     "\n",
     "The list of supported model names:\n",
     "```\n",


### PR DESCRIPTION
I added an integration to search things that [look like TODO comments](https://github.com/marketplace/actions/track-todo-action) and convert them into GitHub issues.

Notably, this integration failed to find the TODO comment inside EasyTransformer_Demo.ipynb. I [manually created an issue for this one](https://github.com/neelnanda-io/Easy-Transformer/issues/55). 

Maybe-someday I'll write my own integration that does something dumber/more robust in that it just looks for the word TODO.