### PR TITLE
Add plotly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         "wandb",
         "fancy_einsum",
         "torchtyping",
+        "plotly",
     ],
 )


### PR DESCRIPTION
I got a `ModuleNotFoundError: No module named 'plotly'` error when first running `pip install`, this fixes it.