### PR TITLE
Fix opt tokenizer

### DIFF
--- a/Exploratory_Analysis_Demo.ipynb
+++ b/Exploratory_Analysis_Demo.ipynb
@@ -392,7 +392,7 @@
    "source": [
     "We now want to find a reference prompt to run the model on. Even though our ultimate goal is to reverse engineer how this behaviour is done in general, often the best way to start out in mechanistic interpretability is by zooming in on a concrete example and understanding it in detail, and only *then* zooming out and verifying that our analysis generalises.\n",
     "\n",
-    "We'll run the model on 4 instances of this task, each prompt given twice - one with the first name as the indirect object, one with the second name. To make our lives easier, we'll carefully choose prompts with single token names and the corresponding names in the same token positions.\n",
+    "We'll run the model on 4 instances of this task, each prompt given twice - one with the first name as the indirect object, one with the second name. To make our lives easier, we'll carefully choose prompts with single token names and the same\n",
     "\n",
     "<details> <summary>(*) <b>Aside on tokenization</b></summary>\n",
     "\n",

--- a/Exploratory_Analysis_Demo.ipynb
+++ b/Exploratory_Analysis_Demo.ipynb
@@ -392,7 +392,7 @@
    "source": [
     "We now want to find a reference prompt to run the model on. Even though our ultimate goal is to reverse engineer how this behaviour is done in general, often the best way to start out in mechanistic interpretability is by zooming in on a concrete example and understanding it in detail, and only *then* zooming out and verifying that our analysis generalises.\n",
     "\n",
-    "We'll run the model on 4 instances of this task, each prompt given twice - one with the first name as the indirect object, one with the second name. To make our lives easier, we'll carefully choose prompts with single token names and the same\n",
+    "We'll run the model on 4 instances of this task, each prompt given twice - one with the first name as the indirect object, one with the second name. To make our lives easier, we'll carefully choose prompts with single token names and the corresponding names in the same token positions.\n",
     "\n",
     "<details> <summary>(*) <b>Aside on tokenization</b></summary>\n",
     "\n",

--- a/easy_transformer/EasyTransformer.py
+++ b/easy_transformer/EasyTransformer.py
@@ -82,7 +82,8 @@ class EasyTransformer(HookedRootModule):
                 self.tokenizer.pad_token = self.tokenizer.eos_token
             if self.tokenizer.bos_token is None:
                 self.tokenizer.bos_token = self.tokenizer.eos_token
-            if isinstance(self.tokenizer, PreTrainedTokenizer):
+            if self.cfg.original_architecture == "OPTForCausalLM":
+                # OPT tokenizer automatically adds BOS token
                 self.tokenizer.add_bos_token = False
         else:
             # If no tokenizer name is provided, we assume we're training on an algorithmic task and will pass in tokens directly. In this case, we don't need a tokenizer.

--- a/easy_transformer/EasyTransformer.py
+++ b/easy_transformer/EasyTransformer.py
@@ -82,6 +82,8 @@ class EasyTransformer(HookedRootModule):
                 self.tokenizer.pad_token = self.tokenizer.eos_token
             if self.tokenizer.bos_token is None:
                 self.tokenizer.bos_token = self.tokenizer.eos_token
+            if isinstance(self.tokenizer, PreTrainedTokenizer):
+                self.tokenizer.add_bos_token = False
         else:
             # If no tokenizer name is provided, we assume we're training on an algorithmic task and will pass in tokens directly. In this case, we don't need a tokenizer.
             self.tokenizer = None

--- a/easy_transformer/EasyTransformer.py
+++ b/easy_transformer/EasyTransformer.py
@@ -21,7 +21,6 @@ from easy_transformer.hook_points import HookedRootModule, HookPoint
 from easy_transformer import EasyTransformerConfig
 from easy_transformer.ActivationCache import ActivationCache
 from easy_transformer.FactoredMatrix import FactoredMatrix
-
 # Note - activation cache is used with run_with_cache, past_key_value_caching is used for generation.
 from easy_transformer.past_key_value_caching import (
     EasyTransformerKeyValueCache,
@@ -83,8 +82,6 @@ class EasyTransformer(HookedRootModule):
                 self.tokenizer.pad_token = self.tokenizer.eos_token
             if self.tokenizer.bos_token is None:
                 self.tokenizer.bos_token = self.tokenizer.eos_token
-            if isinstance(self.tokenizer, PreTrainedTokenizer):
-                self.tokenizer.add_bos_token = False
         else:
             # If no tokenizer name is provided, we assume we're training on an algorithmic task and will pass in tokens directly. In this case, we don't need a tokenizer.
             self.tokenizer = None
@@ -303,7 +300,7 @@ class EasyTransformer(HookedRootModule):
         move_to_device: bool = True,
     ) -> TT["batch", "pos"]:
         """
-        Converts a string to a tensor of tokens. If prepend_bos is True, prepends the BOS token to the input - this is recommended when creating a sequence of tokens to be input to a model.
+        Converts a string to a tensor of tokens. If prepend_bos is True, prepends the BOS token to the input - this is recommended when creating a sequence of tokens to be input to a model. 
 
         Gotcha: prepend_bos prepends a beginning of string token. This is a recommended default when inputting a prompt to the model as the first token is often treated weirdly, but should only be done at the START of the prompt. Make sure to turn it off if you're looking at the tokenization of part of the prompt!
         (Note: some models eg GPT-2 were not trained with a BOS token, others (OPT and my models) were)
@@ -420,8 +417,8 @@ class EasyTransformer(HookedRootModule):
                 search in. Can be a string or a rank 1 tensor or a rank 2 tensor
                 with a dummy batch dimension.
             mode (str, optional): If there are multiple matches, which match to return. Supports "first" or "last". Defaults to "first".
-            prepend_bos (bool): Prepends a BOS (beginning of sequence) token when tokenizing a string. Only matters when inputting a string to
-                the function, otherwise ignored.
+            prepend_bos (bool): Prepends a BOS (beginning of sequence) token when tokenizing a string. Only matters when inputting a string to 
+                the function, otherwise ignored. 
         """
         if isinstance(tokens, str):
             # If the tokens are a string, convert to tensor
@@ -441,7 +438,7 @@ class EasyTransformer(HookedRootModule):
             single_token = single_token.item()
 
         indices = torch.arange(len(tokens))[tokens == single_token]
-        assert len(indices) > 0, f"The token does not occur in the prompt"
+        assert len(indices)>0, f"The token does not occur in the prompt"
         if mode == "first":
             return indices[0].item()
         elif mode == "last":
@@ -449,15 +446,11 @@ class EasyTransformer(HookedRootModule):
         else:
             raise ValueError(f"mode must be 'first' or 'last', not {mode}")
 
-    def tokens_to_residual_directions(
-        self, tokens: Union[str, int, TT[()], TT["position"], TT["batch", "position"]]
-    ) -> Union[
-        TT["d_model"], TT["position", "d_model"], TT["batch", "position", "d_model"]
-    ]:
+    def tokens_to_residual_directions(self, tokens: Union[str, int, TT[()], TT["position"], TT["batch", "position"]]) -> Union[TT["d_model"], TT["position", "d_model"], TT["batch", "position", "d_model"]]:
         """Maps tokens to a tensor with the unembedding vector for those tokens, ie the vector in the residual stream that we dot with to the get the logit for that token.
 
         WARNING: If you use this without folding in LayerNorm, the results will be misleading and may be incorrect, as the LN weights change the unembed map. This is done automatically with the fold_ln flag on from_pretrained
-
+        
         WARNING 2: LayerNorm scaling will scale up or down the effective direction in the residual stream for each output token on any given input token position. ActivationCache.apply_ln_to_stack will apply the appropriate scaling to these directions.
 
         Args:
@@ -467,12 +460,10 @@ class EasyTransformer(HookedRootModule):
         Returns:
             residual_direction torch.Tensor: The unembedding vector for the token(s), a stack of [d_model] tensor.
         """
-        if isinstance(tokens, torch.Tensor) and tokens.numel() > 1:
+        if isinstance(tokens, torch.Tensor) and tokens.numel()>1:
             # If the tokens are a tensor, and have more than one element, assume they are a batch of tokens
             residual_directions = self.W_U[:, tokens]
-            residual_directions = einops.rearrange(
-                residual_directions, "d_model ... -> ... d_model"
-            )
+            residual_directions = einops.rearrange(residual_directions, "d_model ... -> ... d_model")
             return residual_directions
         else:
             # Otherwise there is a single token
@@ -480,12 +471,13 @@ class EasyTransformer(HookedRootModule):
                 token = self.to_single_token(tokens)
             elif isinstance(tokens, int):
                 token = tokens
-            elif isinstance(tokens, torch.Tensor) and tokens.numel() == 1:
+            elif isinstance(tokens, torch.Tensor) and tokens.numel()==1:
                 token = tokens.item()
             else:
                 raise ValueError(f"Invalid token type: {type(tokens)}")
             residual_direction = self.W_U[:, token]
             return residual_direction
+
 
     def to(self, device_or_dtype):
         """


### PR DESCRIPTION
Previously, loading in any OPT model and doing `model.to_token("Hello")` would give the tensor `[2, 2, 5625]`. This fixes that change