### PR TITLE
Remove unused parameter from `generate`

### DIFF
--- a/easy_transformer/EasyTransformer.py
+++ b/easy_transformer/EasyTransformer.py
@@ -948,7 +948,6 @@ class EasyTransformer(HookedRootModule):
         top_p: Optional[float] = None,
         temperature: float = 1.0,
         freq_penalty: float = 0.0,
-        num_return_sequences: int = 1,
         use_past_kv_cache: bool = True,
         prepend_bos=True,
         return_type: Optional[str] = "input",


### PR DESCRIPTION
I searched the file for `num_return_sentences`: there are no other occurrences.