### PR TITLE
Reduce torch required version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1985,7 +1985,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e4125865662ca452e6a56f2cdf5435f2716a7925c0b6bb0b4aec4addfa5eb1da"
+content-hash = "0065d14ac2b18a538fc643d43105797bc1066a35e02adbf88c9646a00d8e7372"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "easy_transformer"}]
 python = "^3.8"
 einops = "^0.6.0"
 numpy = "^1.21"
-torch = "^1.12"
+torch = "^1.10"
 datasets = "^2.7.1"
 transformers = "^4.25.1"
 tqdm = "^4.64.1"


### PR DESCRIPTION
Paperspace installs a much older version by default.